### PR TITLE
Fix Android compilation issues by bumping compile SDK version to 31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ android {
         namespace 'com.crazecoder.openfile'
     }
 
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/153281#issuecomment-2292201697 for more information.

I have not tested this change.